### PR TITLE
fix some compiler warnings

### DIFF
--- a/.github/scripts/msvcprep.bat
+++ b/.github/scripts/msvcprep.bat
@@ -1,0 +1,42 @@
+
+REM  Find Visual Studio [Express] in one of the usual places.
+REM  Expects something like "x86", "amd64", or "x86_amd64" as an argument.
+
+set VCMODE=%1
+
+REM For 2022 and later, look in "Program Files"
+set Applications=%ProgramFiles%
+
+set VCVARBAT=%Applications%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat
+
+REM For 2019 and earlier, look in "Program Files (x86)"
+set Applications=%ProgramFiles(x86)%
+if "%Applications%" == "" set Applications=%ProgramFiles%
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 14.0\vc\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 13.0\vc\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 12.0\vc\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 11.0\vc\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 10.0\vc\vcvarsall.bat
+
+if not exist "%VCVARBAT%" set VCVARBAT=%Applications%\Microsoft Visual Studio 9.0\vc\vcvarsall.bat
+
+"%VCVARBAT%" %VCMODE%

--- a/.github/workflows/zuo-cflags.yml
+++ b/.github/workflows/zuo-cflags.yml
@@ -1,31 +1,45 @@
 ---
 name: Zuo with Strict Compiler Flags
 
-on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - master
-    paths:
-      - "racket/src/zuo/**"
-  pull_request:
-    paths:
-      - "racket/src/zuo/**"
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-direcotry: "racket/src/zuo"
+  build-gcc:
+    runs-on: ubuntu-22.04
 
     env:
-      CFLAGS: "-Werror -Wall -Wextra -Wstrict-prototypes -Wold-style-definition -Wshadow -Wpointer-arith -Wcast-qual -pedantic -O2 -std=c11"
+      CFLAGS: "-Werror -Wall -Wextra -Wstrict-prototypes -Wold-style-definition -Wshadow -Wpointer-arith -Wcast-qual -pedantic -O2 -std=c11 -D_POSIX_C_SOURCE=200809L"
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: Compile
-        run: cc $CFLAGS zuo.c -o zuo
+        run: |
+          gcc -c $CFLAGS -DZUO_EMBEDDED zuo.c -o zuo_embed.o
+          gcc $CFLAGS zuo.c -o zuo
       - name: Check
         run: ./zuo build.zuo check
+
+  build-msvc:
+    runs-on: windows-2022
+
+    env:
+      CFLAGS: "/W1 /WX"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: Compile
+        shell: cmd
+        run: |
+          call .github\scripts\msvcprep.bat x86_amd64
+          cl /c %CFLAGS% /DZUO_EMBEDDED /Fo:zuo_embed.obj zuo.c
+          cl %CFLAGS% zuo.c -o zuo
+      - name: Check
+        shell: cmd
+        run: |
+          call .github\scripts\msvcprep.bat x86_amd64
+          zuo build.zuo check

--- a/.github/workflows/zuo-cflags.yml
+++ b/.github/workflows/zuo-cflags.yml
@@ -1,0 +1,31 @@
+---
+name: Zuo with Strict Compiler Flags
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+    paths:
+      - "racket/src/zuo/**"
+  pull_request:
+    paths:
+      - "racket/src/zuo/**"
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-direcotry: "racket/src/zuo"
+
+    env:
+      CFLAGS: "-Werror -Wall -Wextra -Wstrict-prototypes -Wold-style-definition -Wshadow -Wpointer-arith -Wcast-qual -pedantic -O2 -std=c11"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: Compile
+        run: cc $CFLAGS zuo.c -o zuo
+      - name: Check
+        run: ./zuo build.zuo check

--- a/build.zuo
+++ b/build.zuo
@@ -91,7 +91,7 @@
                           (lambda ()
                             (unless (= 0 (process-status
                                           (thread-process-wait
-                                           (hash-ref (process "to-run/zuo"
+                                           (hash-ref (process (.exe "to-run/zuo")
                                                               (at-source "tests/main.zuo"))
                                                      'process))))
                               (error "check failed")))))))

--- a/tests/file-handle.zuo
+++ b/tests/file-handle.zuo
@@ -155,9 +155,10 @@
                          'stdout 'pipe))])
   (define in (hash-ref ht 'stdout))
   (define out (hash-ref ht 'stdin))
-  (check (fd-poll (list in) 0) #f)
-  (check (fd-poll (list in out) 0) out)
-  (check (fd-poll (list in out)) out)
+  (unless (eq? 'windows (system-type)) ;; polling doesn't work on Windows pipes
+    (check (fd-poll (list in) 0) #f)
+    (check (fd-poll (list in out) 0) out)
+    (check (fd-poll (list in out)) out))
   (fd-write out "x")
   (check (fd-poll (list in)) in)
   (check (fd-poll (list in) 0) in)

--- a/tests/path.zuo
+++ b/tests/path.zuo
@@ -102,7 +102,7 @@
        ".")
 (check (find-relative-path "home/zuo/src" "tmp/cache")
        (build-path ".." ".." ".." "tmp" "cache"))
-(check (find-relative-path "." "tmp/cache")
+(check (find-relative-path "." (build-path "tmp" "cache"))
        (build-path "tmp" "cache"))
 (check (find-relative-path "tmp/cache" ".")
        (build-path ".." ".."))
@@ -148,7 +148,7 @@
 (check-arg-fail (file-name-from-path 10) not-path)
 
 (check (path-replace-extension "a.c" ".o") "a.o")
-(check (path-replace-extension "p/a.c" ".o") (build-path "p" "a.o"))
-(check (path-replace-extension "p/.rc" ".o") (build-path "p" ".rc.o"))
+(check (path-replace-extension "p/a.c" ".o") (build-path "p/a.o"))
+(check (path-replace-extension "p/.rc" ".o") (build-path "p/.rc.o"))
 (check-arg-fail (path-replace-extension 10 "x") not-path)
 (check-arg-fail (path-replace-extension "x" 10) not-string)

--- a/zuo-doc/lang-zuo.scrbl
+++ b/zuo-doc/lang-zuo.scrbl
@@ -1029,7 +1029,9 @@ until at least one is ready, and then it returns the first element of
 @racket[handles] that is ready. If @racket[timeout-msecs] is a number,
 then it specifies a number of milliseconds to wait; the result is
 @racket[#f] if no handle in @racket[handles] is ready before
-@racket[timeout-msecs] milliseconds pass.
+@racket[timeout-msecs] milliseconds pass. Polling typically does not
+work on Windows, because pipe handles claim to be ready for reading even
+when no data is available.
 
 @history[#:added "1.1"]}
 

--- a/zuo.h
+++ b/zuo.h
@@ -35,7 +35,7 @@ typedef struct zuo_t zuo_ext_t;
    primitives will effectively remove them by using the image's
    `kernel-env`.
  */
-ZUO_EXPORT void zuo_ext_primitive_init();
+ZUO_EXPORT void zuo_ext_primitive_init(void);
 
 /* Add more primitives only after calling `zuo_ext_primitive_init`: */
 typedef zuo_ext_t *(*zuo_ext_primitive_t)(zuo_ext_t *args_list);
@@ -51,12 +51,12 @@ ZUO_EXPORT void zuo_ext_image_init(char *boot_image_file);
 /* After calling `zuo_ext_image_init`, the following functions are available: */
 
 /* Functions that get a constant: */
-ZUO_EXPORT zuo_ext_t *zuo_ext_false();
-ZUO_EXPORT zuo_ext_t *zuo_ext_true();
-ZUO_EXPORT zuo_ext_t *zuo_ext_null();
-ZUO_EXPORT zuo_ext_t *zuo_ext_void();
-ZUO_EXPORT zuo_ext_t *zuo_ext_eof();
-ZUO_EXPORT zuo_ext_t *zuo_ext_empty_hash();
+ZUO_EXPORT zuo_ext_t *zuo_ext_false(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_true(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_null(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_void(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_eof(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_empty_hash(void);
 
 /* Other data constructors and accessors: */
 ZUO_EXPORT zuo_ext_t *zuo_ext_integer(long long i);
@@ -74,7 +74,7 @@ ZUO_EXPORT zuo_ext_t *zuo_ext_hash_set(zuo_ext_t *ht, zuo_ext_t *key, zuo_ext_t 
 /* To get more functions, use a symbol key to look them up in the
    kernel environment via `zuo_ext_hash_ref` --- but don't try to
    load, evaluate, or use any modules, yet: */
-ZUO_EXPORT zuo_ext_t *zuo_ext_kernel_env();
+ZUO_EXPORT zuo_ext_t *zuo_ext_kernel_env(void);
 
 /* At this stage, use `zuo_ext_apply` to apply primitives that don't
    evaluate. After `zuo_ext_runtime_init`, use this to apply and
@@ -115,7 +115,7 @@ ZUO_EXPORT zuo_ext_t *zuo_ext_eval_module(zuo_ext_t *as_module_path, const char 
 /* For saving and retriving a value across an evaluation, which is
    when a GC might happen: */
 ZUO_EXPORT void zuo_ext_stash_push(zuo_ext_t *v);
-ZUO_EXPORT zuo_ext_t *zuo_ext_stash_pop();
+ZUO_EXPORT zuo_ext_t *zuo_ext_stash_pop(void);
 
 #endif
 


### PR DESCRIPTION
This cherry-picked the commits from https://github.com/racket/racket/pull/4971 to the Zuo repo to merge here first.

Outstanding items:
- The zuo-cflags workflow should be updated to run on (at least) Windows. I know how to configure the build matrix but not the Windows compiler.

---

To create this branch (in case it's helpful to future readers):
1. [Racket repo: `zuo-compiler-warnings` branch] I extracted the Zuo commits from `racket/src/zuo` with `git format-patch master..@~ --relative=racket/src/zuo -o zuo-patches`. This controlled the paths in the patch so they apply easily to this repo. (Going the other direction wants the `--diretory` option on `git am` or `git apply`.)
2. [Change to Zuo repo] I applied those patches with `git am $OLDPWD/zuo-patches/*`.
3. I extracted and applied the GitHub Actions patch with `(cd $OLDPWD && git format-patch @~.. --stdout) | git am`. I did then `git commit --amend` that patch to tidy up the references.