### PR TITLE
update lang-zuo.scrbl `define` syntax optional arguments

### DIFF
--- a/zuo-doc/lang-zuo.scrbl
+++ b/zuo-doc/lang-zuo.scrbl
@@ -198,8 +198,7 @@ Produces the module path of the enclosing module.}
            (define (id . formals) body ...++)]]{
 
 Like @realracket*[define] from @racketmodname[racket], but without
-keyword arguments, optional arguments, or header nesting for curried
-functions.}
+keyword arguments and header nesting for curried functions.}
 
 @defform*[[(define-syntax id expr)
            (define-syntax (id . formals) body ...++)]]{


### PR DESCRIPTION
zuo `define` should support optional arguments

I don't quite understand the implementation of define, but I tried version `1.10` of zuo and it seems that optional arguments works.


