### PR TITLE
Add support for building with Zig

### DIFF
--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -1,0 +1,29 @@
+# This workflow is for zig-based build/test running on Linux, MacOS, Windows.
+name: Zig build
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    name: ${{ matrix.os }} ${{ matrix.ttriple }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        zig_version: [ "0.14.0" ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        ttriple: [ native ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: korandoru/setup-zig@v1
+      with:
+        zig-version: ${{ matrix.zig_version }}
+    - name: Build
+      run: >
+        zig build -Dtarget=${{ matrix.ttriple }}
+        -Denable_werror
+        test

--- a/.github/workflows/zig-cross-build.yml
+++ b/.github/workflows/zig-cross-build.yml
@@ -1,0 +1,78 @@
+# This workflow uses Zig and its excellent cross-compilation support to test
+# compiling for multiple platforms. No tests are actually run since it would
+# require emulation.
+name: Zig cross-compile
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    name: ${{ matrix.ttriple }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        zig_version: [ "0.14.0" ]
+        ttriple: [
+          aarch64-linux-gnu,
+          aarch64-linux-musl,
+          #aarch64-macos-none,
+          aarch64-windows-gnu,
+          aarch64_be-linux-gnu,
+          aarch64_be-linux-musl,
+          arm-linux-gnueabi,
+          arm-linux-gnueabihf,
+          arm-linux-musleabi,
+          arm-linux-musleabihf,
+          armeb-linux-gnueabi,
+          armeb-linux-gnueabihf,
+          armeb-linux-musleabi,
+          armeb-linux-musleabihf,
+          loongarch64-linux-gnu,
+          loongarch64-linux-musl,
+          mips-linux-gnueabi,
+          mips-linux-gnueabihf,
+          mips-linux-musleabi,
+          mips64-linux-gnuabi64,
+          mips64-linux-gnuabin32,
+          mips64-linux-muslabi64,
+          mips64el-linux-gnuabi64,
+          mips64el-linux-gnuabin32,
+          mips64el-linux-muslabi64,
+          mipsel-linux-gnueabi,
+          mipsel-linux-gnueabihf,
+          mipsel-linux-musleabi,
+          powerpc-linux-gnueabi,
+          powerpc-linux-gnueabihf,
+          #powerpc-linux-musl,
+          #powerpc64-linux-gnu, # FIXME: as of zig 0.14, not implemented correctly.
+          powerpc64-linux-musl,
+          powerpc64le-linux-gnu,
+          powerpc64le-linux-musl,
+          riscv32-linux-gnu,
+          riscv32-linux-musl,
+          riscv64-linux-musl,
+          #sparc64-linux-gnu,
+          thumb-linux-musleabi,
+          thumb-linux-musleabihf,
+          #wasm32-wasi-musl, # wasm lacks signal support.
+          x86-linux-gnu,
+          x86-linux-musl,
+          x86-windows-gnu,
+          x86_64-linux-gnu.2.27, # with a glibc version
+          x86_64-linux-gnux32,
+          x86_64-linux-musl,
+          #x86_64-macos-none,
+          x86_64-windows-gnu,
+        ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: korandoru/setup-zig@v1
+      with:
+        zig-version: ${{ matrix.zig_version }}
+    - name: Build
+      run: >
+        zig build -Dtarget=${{ matrix.ttriple }}
+        -Denable_werror

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,217 @@
+// A script to build and test the zuo using Zig build system.
+// The script matches build.zuo as much as possible.
+
+const builtin = @import("builtin");
+const std = @import("std");
+
+const zig_min_required_version = "0.14.0";
+
+comptime {
+    const required_ver = std.SemanticVersion.parse(zig_min_required_version)
+                            catch unreachable;
+    if (builtin.zig_version.order(required_ver) == .lt) {
+        @compileError(std.fmt.comptimePrint(
+            "Zig version {} does not meet the build requirement of {}",
+            .{ builtin.zig_version, required_ver },
+        ));
+    }
+}
+
+pub fn build(b: *std.Build) void {
+    // Stage 0
+
+    // Install lib/zuo to standard lib path.
+    const lib = b.addInstallDirectory(.{
+        .source_dir = b.path("lib/zuo"),
+        .install_dir = .{ .lib = {} },
+        .install_subdir = "zuo",
+    });
+
+    // zuo0 is only used to generate image_zuo.c file.
+
+    // zuo0 is built to native target by default.
+    // In some sepcial situation, user can set the target manually.
+    const zuo0_target_option = b.option([]const u8, "zuo0-target",
+        "zuo0 target (or else native)") orelse "native";
+    const zuo0_query_result = std.Build.parseTargetQuery(.{
+        .arch_os_abi = zuo0_target_option,
+    }) catch unreachable;
+    const zuo0_t = b.resolveTargetQuery(zuo0_query_result).result;
+
+    const zuo0_linkage = b.option(std.builtin.LinkMode,
+        "zuo0-linkage",
+        "zuo0 link mode (default dynamic link)") orelse .dynamic;
+
+    var escaped_path = std.ArrayList(u8).init(b.allocator);
+    defer escaped_path.deinit();
+    escapeWindowsPath(b.lib_dir, &escaped_path) catch unreachable;
+
+    const zuo0 = b.addExecutable(.{
+        .linkage = zuo0_linkage,
+        .name = "zuo0",
+        .root_module = b.createModule(.{
+            .target = b.resolveTargetQuery(zuo0_query_result),
+            .link_libc = true,
+        }),
+    });
+
+    zuo0.addCSourceFile(.{
+        .file = b.path("zuo.c"),
+        .flags = &.{
+            std.mem.concat(b.allocator, u8, &.{
+                "-DZUO_LIB_PATH=",
+                "\"",
+                if (zuo0_t.os.tag == .windows) escaped_path.items
+                else b.lib_dir,
+                "\"",
+            }) catch unreachable,
+            if (zuo0_t.isMinGW()) "-D__MINGW32__"
+            else if (zuo0_t.os.tag == .windows) "-D_MSC_VER=1700"
+            else "",
+        },
+    });
+
+    // Run local/image.zuo script to generate image_zuo.c file.
+    const image_zuo = b.addRunArtifact(zuo0);
+    image_zuo.addFileArg(b.path("local/image.zuo"));
+    image_zuo.addArgs(&.{
+        "-o", "image_zuo.c",
+        "++lib", "zuo",
+        "--keep-collects",
+    });
+    image_zuo.setCwd(b.path(""));
+    image_zuo.step.dependOn(&lib.step);
+
+    // Stage 1
+
+    // Shared configuration for to-run zuo and to-install zuo.
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const t = target.result;
+
+    const linkage = b.option(std.builtin.LinkMode, "linkage",
+        "Link mode (default dynamic link)") orelse .dynamic;
+    const cflags_extra = b.option([]const u8, "cflags-extra",
+        "Extra user-defined cflags") orelse "";
+
+    const enable_werror = b.option(bool, "enable_werror",
+        "Pass -Werror to the C compiler (treat warnings as errors)")
+        orelse false;
+
+    var source_files = std.ArrayList([]const u8).init(b.allocator);
+    defer source_files.deinit();
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+
+    source_files.appendSlice(&.{
+        "image_zuo.c",
+    }) catch unreachable;
+
+    if(t.isMinGW()) {
+        flags.append("-D__MINGW32__") catch unreachable;
+    } else if (t.os.tag == .windows) {
+        // If the version of the Microsoft C/C++ compiler is 17.00.51106.1,
+        // the value of _MSC_VER is 1700.
+        // This maybe better then an arbitrary value.
+        flags.append("-D_MSC_VER=1700") catch unreachable;
+    }
+
+    // Extra user-defined flags (if any) to pass to the compiler.
+    if (cflags_extra.len > 0) {
+        // Split it up on a space and append each part to flags separately.
+        var tokenizer = std.mem.tokenizeScalar(u8, cflags_extra, ' ');
+        while (tokenizer.next()) |token| {
+            flags.append(token) catch unreachable;
+        }
+    }
+
+    if (enable_werror) {
+        flags.append("-Werror") catch unreachable;
+    }
+
+    // same as to-install zuo in build.zuo
+    const zuo = b.addExecutable(.{
+        .linkage = linkage,
+        .name = "zuo",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+
+    flags.append(std.mem.concat(b.allocator, u8, &.{
+        "-DZUO_LIB_PATH=",
+        "\"",
+        if (zuo0_t.os.tag == .windows) escaped_path.items
+        else b.lib_dir,
+        "\"",
+        }) catch unreachable
+    ) catch unreachable;
+
+    zuo.addCSourceFiles(.{
+        .files = source_files.items,
+        .flags = flags.items,
+    });
+
+    zuo.step.dependOn(&image_zuo.step);
+    b.installArtifact(zuo);
+
+    // same as to-run zuo in build.zuo
+    const to_run = b.addExecutable(.{
+        .linkage = linkage,
+        .name = "zuo",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+
+    // pop -DZUO_LIB_PATH flag for to-install zuo, share the other flags.
+    _ = flags.pop();
+
+    if (t.os.tag == .windows) {
+        // DZUO_LIB_PATH is a C macro, there are double amount of separators.
+        flags.append("-DZUO_LIB_PATH=\"..\\\\lib\"") catch unreachable;
+    } else {
+        flags.append("-DZUO_LIB_PATH=\"../lib\"") catch unreachable;
+    }
+
+    to_run.addCSourceFiles(.{
+        .files = source_files.items,
+        .flags = flags.items,
+    });
+
+    to_run.step.dependOn(&image_zuo.step);
+    const to_run_install = b.addInstallArtifact(to_run, .{
+        .dest_dir = .{.override = .{.custom = "to-run"}},
+    });
+    const to_run_step = b.step("to-run", "Build and install to-run zuo in build.zuo script");
+    to_run_step.dependOn(&to_run_install.step);
+
+    // Tests for to-install zuo.
+    const test_step = b.step("test", "Run tests");
+
+    const run_test_zuo = b.addRunArtifact(zuo);
+    run_test_zuo.addFileArg(b.path("tests/main.zuo"));
+    test_step.dependOn(&run_test_zuo.step);
+}
+
+fn escapeWindowsPath(path: []const u8, escaped: *std.ArrayList(u8)) !void {
+    escaped.clearAndFree();
+    for (path) |char| {
+        if (char == '\\') {
+            escaped.append('\\') catch unreachable;
+            escaped.append('\\') catch unreachable;
+        } else {
+            escaped.append(char) catch unreachable;
+        }
+    }
+    // Add trailing path separator.
+    if (escaped.getLast() != '\\') {
+        escaped.append('\\') catch unreachable;
+        escaped.append('\\') catch unreachable;
+    }
+    return;
+}


### PR DESCRIPTION
This adds a `build.zig` that allows building zuo using the Zig build system. It can be viewed as a substitute for `configure`, `Makefile.in` and `build.zuo` in the current repository. 

Comparing with `configure` and `Makefile.in`, Zig build system has better support for Windows. Zig also have better support for cross compiling. If you want to build zuo for `riscv64-linux-musl`, you only need to type `zig build -Dtarget=riscv64-linux-musl` in terminal on Linux, macOS and even Windows.

Another advantage is the Zig build system is bundled with the language itself. You don't need to prepare additional toolchain.

The `build.zig` script simulates `build.zuo`'s behavior. When you run `zig build` in terminal, it will compile `zuo.c` to `zuo0` executable. The `zuo0` executes `local/image.zuo` to generate `image_zuo.c`. Then zig can compile `image_zuo.c` for any target using `zig build -Dtaget=<target>` flag, such as aarch64, riscv and loongarch.

Tis script compiles two executables that equivalent to to-install zuo and to-run zuo. The to-install zuo is put into `prefix/bin` and the to-run zuo is put into `prefix/to-run`. Files under `lib/zuo` are copied into standard lib path.

Run `zig build test` will execute `tests/main.zuo` using to-install zuo that to installed into `prefix/bin`.