### PR TITLE
Zuo: fix missing struct predicates under `#lang zuo/hygienic`

### DIFF
--- a/lib/zuo/private/base-common/struct.zuo
+++ b/lib/zuo/private/base-common/struct.zuo
@@ -23,7 +23,7 @@
       (bad-syntax stx))
     (define key `(,(quote-syntax quote)
                   ,(string->uninterned-symbol (symbol->string (syntax-e name)))))
-    (define name? (string->symbol (datum->syntax name (~a (syntax-e name) "?"))))
+    (define name? (datum->syntax name (string->symbol (~a (syntax-e name) "?"))))
     `(,(quote-syntax begin)
       (,(quote-syntax define) ,name
                               (,(quote-syntax lambda)


### PR DESCRIPTION
Fix to https://github.com/racket/zuo/issues/30#issue-4344745034.

Thanks,
MT